### PR TITLE
feat(branding): Adds branding settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Example:
     "url": "<GITHUB REPO URL>",
     "version": "0.1.0",
     "indexModule": "Welcome",
+    "logo": "path/to/logo.png",
+    "primaryColor": "orange",
     "externalDocs": [{
         "name": "ember-validators",
         "path": "node_modules/ember-validators",
@@ -47,7 +49,6 @@ Example:
     }
 }
 ```
-
 
 ## Index Module
 
@@ -71,5 +72,17 @@ If you have external documentation taken from dependencies, you may list them un
         "url": "https://github.com/offirgolan/ember-validators",
         "version": "master"
     }]
+}
+```
+
+## Branding Settings
+
+The `logo` and `primaryColor` options can be specified in yuidoc.json to set the logo displayed in the upper
+left hand corner and the accent color used throughout the theme.
+
+```json
+{
+    "logo": "path/to/logo.png",
+    "primaryColor": "orange"
 }
 ```

--- a/layouts/main.handlebars
+++ b/layouts/main.handlebars
@@ -14,13 +14,48 @@
     <link href='https://fonts.googleapis.com/css?family=Open+Sans:300,400,500,600,700' rel='stylesheet' type='text/css'>
     {{!-- <link rel="shortcut icon" type="image/png" href="{{projectAssets}}/favicon.png"> --}}
     {{setupGlobals}}
+
+    {{#if projectPrimaryColor}}
+      <style>
+        body a {
+          color: {{projectPrimaryColor}};
+        }
+        body a:hover {
+          color: {{projectPrimaryColor}};
+          opacity: 0.5;
+        }
+        .navbar.navbar-default .navbar-nav> li> a:focus, .navbar.navbar-default .navbar-nav> li> a:hover {
+          color: {{projectPrimaryColor}};
+        }
+        .navbar.navbar-default .navbar-nav> .active> a, .navbar.navbar-default .navbar-nav> .active> a:focus, .navbar.navbar-default .navbar-nav> .active> a:hover {
+          color: {{projectPrimaryColor}};
+        }
+        #docs-main .page-header {
+          color: {{projectPrimaryColor}};
+        }
+        #docs-main .page-section .nav-tabs {
+          border-bottom: 1px solid {{projectPrimaryColor}};
+        }
+        #docs-main .page-section .nav-tabs> li.active a {
+          background: {{projectPrimaryColor}};
+          border: 1px solid {{projectPrimaryColor}};
+        }
+        #sidebar li.panel .panel-body ol> li.active, #sidebar li.panel .panel-body ol> li:hover {
+          background: #efefef;
+        }
+      </style>
+    {{/if}}
 </head>
 <body>
     <nav class="navbar navbar-default">
       <div class="container-fluid">
         <div class="navbar-header">
           <a href="{{projectRoot}}" class="navbar-brand">
-            <img src="{{projectAssets}}/img/ember-logo.png" alt="">
+            {{#if projectLogo}}
+              <img src="{{projectLogo}}" alt="enterprise logo">
+            {{else}}
+              <img src="{{projectAssets}}/img/ember-logo.png" alt="enterprise logo">
+            {{/if}}
             <span>{{deEmberifiedName}}</span>
           </a>
         </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yuidoc-ember-theme",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "YUIDoc theme for ember addons",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Implements #4 

Super simple implementation, just gives the users the ability to specify a logo path and the accent color. Makes use of opacity to distinguish link colors, and changes the highlight color in the link list to be a neutral grey (it's still hard to do things like `lighten` and `darken` in plain old CSS).