### PR TITLE
Adds import location to class declarations.

### DIFF
--- a/helpers/helpers.js
+++ b/helpers/helpers.js
@@ -6,6 +6,10 @@ module.exports = {
     console.log.apply(console, slicedArgs);
   },
 
+  parseImport: function(item) {
+    return item.replace(/^addon/, PROJECT.projectName).replace(/^app/, 'your-app-name')
+  },
+
   setupGlobals: function() {
     PROJECT = this;
     return '';

--- a/helpers/helpers.js
+++ b/helpers/helpers.js
@@ -7,7 +7,7 @@ module.exports = {
   },
 
   parseImport: function(item) {
-    return item.replace(/^addon/, PROJECT.projectName).replace(/^app/, 'your-app-name')
+    return item.replace(/^addon/, PROJECT.projectName).replace(/^app/, 'your-app-name').replace(/\.js$/, '');
   },
 
   setupGlobals: function() {

--- a/partials/classes.handlebars
+++ b/partials/classes.handlebars
@@ -73,6 +73,12 @@
     </div>
 {{/is_constructor}}
 
+<pre class="code prettyprint">
+  <code class="language-javascript">
+    import {{name}} from '{{parseImport file}}'
+  </code>
+</pre>
+
 {{#if classDescription}}
   <div class="class-description">
   {{{classDescription}}}


### PR DESCRIPTION
Adds import location, similar to what is on the official ember docs.

Replaces `addon` path with the package name, and `app` paths with the string `your-app-name`.

Probably won't work with module-unification packages. Open to suggestions. Maybe make this optional in yuidoc.json?

Here's a preview:
<img width="823" alt="screen shot 2018-12-10 at 11 22 44 am" src="https://user-images.githubusercontent.com/1163812/49756094-76879800-fc6e-11e8-8d54-464ce2ff3389.png">

